### PR TITLE
Enable support for array indexing

### DIFF
--- a/expr.go
+++ b/expr.go
@@ -115,7 +115,6 @@ func (a *aggregator) Evaluate(ctx context.Context, data map[string]any) ([]Evalu
 	// TODO: Concurrently match constant expressions using a semaphore for capacity.
 	for _, expr := range a.constants {
 		atomic.AddInt32(&matched, 1)
-
 		// NOTE: We don't need to add lifted expression variables,
 		// because match.Parsed.Evaluable() returns the original expression
 		// string.

--- a/parser_test.go
+++ b/parser_test.go
@@ -69,9 +69,41 @@ func TestParse(t *testing.T) {
 		}
 	}
 
+	t.Run("It handles array indexing", func(t *testing.T) {
+		tests := []parseTestInput{
+			{
+				input:  `event.data.ids[2] == "a"`,
+				output: `event.data.ids[2] == "a"`,
+				expected: ParsedExpression{
+					Root: Node{
+						Predicate: &Predicate{
+							Ident:    "event.data.ids[2]",
+							Literal:  "a",
+							Operator: operators.Equals,
+						},
+					},
+				},
+			},
+			{
+				input:  `event.data.ids[2].id == "a"`,
+				output: `event.data.ids[2].id == "a"`,
+				expected: ParsedExpression{
+					Root: Node{
+						Predicate: &Predicate{
+							Ident:    "event.data.ids[2].id",
+							Literal:  "a",
+							Operator: operators.Equals,
+						},
+					},
+				},
+			},
+		}
+
+		assert(t, tests)
+	})
+
 	t.Run("It handles ident matching", func(t *testing.T) {
 		ident := "vars.a"
-		_ = ident
 
 		tests := []parseTestInput{
 			{


### PR DESCRIPTION
Allow support for parsing and aggregate tree matching when using array indexing `event.data.ids[1] == "yea"`.