### PR TITLE
Handle priting of nils in a JSON compatible manner

### DIFF
--- a/expr_test.go
+++ b/expr_test.go
@@ -754,6 +754,20 @@ func TestAddRemove(t *testing.T) {
 		require.EqualValues(t, 1, count)
 		require.EqualValues(t, 1, len(eval))
 		require.NoError(t, err)
+
+		// Matching this expr should now fail.
+		eval, count, err = e.Evaluate(ctx, map[string]any{
+			"event": map[string]any{
+				"data": map[string]any{
+					"foo": "yea",
+					"bar": "baz",
+				},
+			},
+		})
+
+		require.EqualValues(t, 1, count)
+		require.EqualValues(t, 0, len(eval))
+		require.NoError(t, err)
 	})
 }
 

--- a/parser.go
+++ b/parser.go
@@ -326,6 +326,13 @@ func (p Predicate) String() string {
 	switch str := p.Literal.(type) {
 	case string:
 		return fmt.Sprintf("%s %s %v", p.Ident, strings.ReplaceAll(p.Operator, "_", ""), strconv.Quote(str))
+	case nil:
+		if p.LiteralIdent == nil {
+			// print `foo == null` instead of `foo == <nil>`, the Golang default.
+			// We onyl do this if we're not comparing to an identifier.
+			return fmt.Sprintf("%s %s null", p.Ident, strings.ReplaceAll(p.Operator, "_", ""))
+		}
+		return fmt.Sprintf("%s %s %v", p.Ident, strings.ReplaceAll(p.Operator, "_", ""), lit)
 	default:
 		return fmt.Sprintf("%s %s %v", p.Ident, strings.ReplaceAll(p.Operator, "_", ""), lit)
 	}

--- a/parser_test.go
+++ b/parser_test.go
@@ -1060,7 +1060,7 @@ func TestParse(t *testing.T) {
 		tests := []parseTestInput{
 			{
 				input:  `has(event.name)`,
-				output: "name select <nil>",
+				output: "name select null",
 				expected: ParsedExpression{
 					Root: Node{
 						GroupID: newGroupID(1),
@@ -1079,7 +1079,7 @@ func TestParse(t *testing.T) {
 			},
 			{
 				input:  `event.data.num.filter(x, x >= 10)`,
-				output: "x comprehension <nil>",
+				output: "x comprehension null",
 				expected: ParsedExpression{
 					Root: Node{
 						GroupID: newGroupID(1),


### PR DESCRIPTION
This removes the <nil> formatting from .String()