### PR TITLE
INN-4727: Fix stripping of valid division operator

### DIFF
--- a/lift.go
+++ b/lift.go
@@ -86,11 +86,12 @@ func (l *liftParser) lift() (string, LiftedArgs) {
 
 		switch char {
 		case '/':
-			// if the next item is a comment, ignore the line.
-			if len(l.expr) > l.idx && l.expr[l.idx] == '/' {
+			// if the next character is a slash, this is a comment line ("//")
+			if len(l.expr) > l.idx && string(l.expr[l.idx]) == "/" {
 				comment = true
 				continue
 			}
+			l.rewritten.WriteByte(char)
 		case '"':
 			// Consume the string arg.
 			val := l.consumeString('"')

--- a/lift_test.go
+++ b/lift_test.go
@@ -39,7 +39,7 @@ func TestLiftLiterals(t *testing.T) {
 			},
 		},
 		{
-			name: "more complex",
+			name: "multiple lines with comments",
 			expr: `
 			// we're breaking it
 			event.name == "test/yolo" || event.name == 'test/foobar'
@@ -51,9 +51,9 @@ func TestLiftLiterals(t *testing.T) {
 			},
 		},
 		{
-			name:         "more complex",
-			expr:         `/`,
-			expectedStr:  "",
+			name:         "division operator",
+			expr:         `event.ts / 1000 > 1745436368`,
+			expectedStr:  `event.ts / 1000 > 1745436368`,
 			expectedArgs: map[string]any{},
 		},
 		{
@@ -61,6 +61,14 @@ func TestLiftLiterals(t *testing.T) {
 			expr:         `// foo`,
 			expectedStr:  "",
 			expectedArgs: map[string]any{},
+		},
+		{
+			name:        "ignore trailing comments",
+			expr:        `event.name == "test/yolo" // foo`,
+			expectedStr: "event.name == vars.a",
+			expectedArgs: map[string]any{
+				"a": "test/yolo",
+			},
 		},
 	}
 


### PR DESCRIPTION
Fixes issue introduced with comment stripping in ff4414ca43f1ad0e019d8b246a844dfe4a947cc5

INN-4727