### PR TITLE
Add support for `"foo" in vars.a`

### DIFF
--- a/.github/workflows/go.yaml
+++ b/.github/workflows/go.yaml
@@ -18,7 +18,7 @@ jobs:
           go-version-file: ./go.mod
       - name: Lint
         run: |
-          curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s v1.61.0
+          curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s v2.1.2
           ./bin/golangci-lint run --verbose
 
   test-linux-race:

--- a/engine_number.go
+++ b/engine_number.go
@@ -135,7 +135,7 @@ func (n *numbers) Search(ctx context.Context, variable string, input any, result
 func (n *numbers) Add(ctx context.Context, p ExpressionPart) error {
 	// If this is not equals, ignore.
 	if p.Predicate.Operator == operators.NotEquals {
-		return fmt.Errorf("Number engine does not support !=")
+		return fmt.Errorf("number engine does not support !=")
 	}
 
 	// Add the number to the btree.
@@ -185,7 +185,7 @@ func (n *numbers) Add(ctx context.Context, p ExpressionPart) error {
 func (n *numbers) Remove(ctx context.Context, p ExpressionPart) error {
 	// If this is not equals, ignore.
 	if p.Predicate.Operator == operators.NotEquals {
-		return fmt.Errorf("Number engine does not support !=")
+		return fmt.Errorf("number engine does not support !=")
 	}
 
 	// Add the number to the btree.

--- a/expr.go
+++ b/expr.go
@@ -634,28 +634,30 @@ func (a *aggregator[T]) iterGroup(ctx context.Context, node *Node, parsed *Parse
 func engineType(p Predicate) EngineType {
 	// switch on type of literal AND operator type.  int64/float64 literals require
 	// btrees, texts require ARTs, and so on.
-	switch p.Literal.(type) {
+	switch v := p.Literal.(type) {
 	case int, int64, float64:
 		if p.Operator == operators.NotEquals {
-			// StringHash is only used for matching on equality.
 			return EngineTypeNone
 		}
 		// return EngineTypeNone
 		return EngineTypeBTree
 	case string:
-		if p.Operator == operators.Equals || p.Operator == operators.NotEquals {
+		if len(v) == 0 {
+			return EngineTypeNone
+		}
+		// NOTE: operators.In acts as operators.Equals, but iterates over the given
+		// array to check each item.
+		if p.Operator == operators.In || p.Operator == operators.Equals || p.Operator == operators.NotEquals {
 			// StringHash is only used for matching on in/equality.
 			return EngineTypeStringHash
 		}
 	case nil:
-		// Only allow this if we're not comparing two idents.
+		// Only allow this if we're not comparing two idents.each element of the array and
 		if p.LiteralIdent != nil {
 			return EngineTypeNone
 		}
 		return EngineTypeNullMatch
 	}
-	// case int64, float64:
-	// 	return EngineTypeBTree
 
 	return EngineTypeNone
 }
@@ -732,27 +734,6 @@ func isAggregateable(n *Node) bool {
 		return false
 	}
 
-	switch v := n.Predicate.Literal.(type) {
-	case string:
-		if len(v) == 0 {
-			return false
-		}
-		if n.Predicate.Operator == operators.NotEquals {
-			// NOTE: NotEquals is _not_ supported.  This requires selecting all leaf nodes _except_
-			// a given leaf, iterating over a tree.  We may as well execute every expressiona s the difference
-			// is negligible.
-			return false
-		}
-		// Right now, we only support equality checking.
-		// TODO: Add GT(e)/LT(e) matching with tree iteration.
-		return n.Predicate.Operator == operators.Equals
-	case int, int64, float64:
-		return true
-	case nil:
-		// This is null, which is supported and a simple lookup to check
-		// if the event's key in question is present and is not nil.
-		return true
-	default:
-		return false
-	}
+	// If the engine type is none... this is non-aggregateable
+	return engineType(*n.Predicate) != EngineTypeNone
 }

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/inngest/expr
 
-go 1.23.2
+go 1.24
 
 require (
 	github.com/cespare/xxhash/v2 v2.2.0

--- a/kvdb.go
+++ b/kvdb.go
@@ -65,7 +65,9 @@ func (p *EvalKV[T]) Get(evalID uuid.UUID) (T, error) {
 	if err != nil {
 		return response, err
 	}
-	defer closer.Close()
+	defer func() {
+		_ = closer.Close()
+	}()
 	return p.opts.Unmarshal(byt)
 }
 


### PR DESCRIPTION
This PR adds support for in-memory aggregate matching using the `in` operator for strings.