### PR TITLE
add options for devserver

### DIFF
--- a/kvdb.go
+++ b/kvdb.go
@@ -28,6 +28,11 @@ type KVOpts[T Evaluable] struct {
 	FS vfs.FS
 	// Dir is the direcorty to store the KV data within.
 	Dir string
+	// BlockCacheSize is the size of the pebble block cache in bytes.  Defaults to 512MB.
+	BlockCacheSize int64
+	// DisableBloomFilter disables the bloom filter on L0 SSTs.  The filter is
+	// pointless with an in-memory FS since there are no disk reads to avoid.
+	DisableBloomFilter bool
 }
 
 // New returns a new temporary EvalKV KV store written to disk.
@@ -39,11 +44,17 @@ func NewKV[T Evaluable](o KVOpts[T]) (KV[T], error) {
 		o.FS = vfs.Default
 	}
 
+	cacheSize := o.BlockCacheSize
+	if cacheSize == 0 {
+		cacheSize = 512 << 20
+	}
+	blockCache := pebble.NewCache(cacheSize)
+
 	// closely following some of cockroachdb defaults
 	// https://github.com/cockroachdb/cockroach/blob/5a1f5da5bb3b2d962d8737848a4fca69f915dacb/pkg/storage/pebble.go#L668-L673
 	opts := &pebble.Options{
 		FS:                          o.FS,
-		Cache:                       pebble.NewCache(512 << 20),
+		Cache:                       blockCache,
 		DisableWAL:                  true,
 		L0CompactionThreshold:       8,
 		L0StopWritesThreshold:       1000,
@@ -51,12 +62,15 @@ func NewKV[T Evaluable](o KVOpts[T]) (KV[T], error) {
 		MemTableStopWritesThreshold: 4,
 		CompactionConcurrencyRange:  func() (int, int) { return 1, 4 },
 	}
-	opts.Levels[0] = pebble.LevelOptions{
+	l0 := pebble.LevelOptions{
 		BlockSize:      32 << 10,
 		IndexBlockSize: 256 << 10,
-		FilterPolicy:   bloom.FilterPolicy(10),
-		FilterType:     pebble.TableFilter,
 	}
+	if !o.DisableBloomFilter {
+		l0.FilterPolicy = bloom.FilterPolicy(10)
+		l0.FilterType = pebble.TableFilter
+	}
+	opts.Levels[0] = l0
 	opts.Levels[0].EnsureL0Defaults()
 
 	db, err := pebble.Open(o.Dir, opts)


### PR DESCRIPTION
We probably don't need a larger block cache / bloom filters for devserver/self-hosted
since we use pebbledb in-memory.
